### PR TITLE
Version 1.0.6

### DIFF
--- a/pure_ldp/frequency_oracles/hadamard_response/hr_client.py
+++ b/pure_ldp/frequency_oracles/hadamard_response/hr_client.py
@@ -14,7 +14,9 @@ class HadamardResponseClient(FreqOracleClient):
         """
         super().__init__(epsilon, d, index_mapper=index_mapper)
         self.update_params(epsilon,d,index_mapper)
-        self.hr.permute = hash_funcs
+
+        if self.epsilon > 1:
+            self.hr.permute = hash_funcs
 
     def update_params(self, epsilon=None, d=None, index_mapper=None):
         """

--- a/pure_ldp/frequency_oracles/hadamard_response/hr_server.py
+++ b/pure_ldp/frequency_oracles/hadamard_response/hr_server.py
@@ -18,7 +18,10 @@ class HadamardResponseServer(FreqOracleServer):
         self.set_name("Hadamard Response")
 
     def get_hash_funcs(self):
-        return self.hr.permute
+        if self.epsilon > 1:
+            return self.hr.permute
+        else:
+            return
 
     def reset(self):
         """

--- a/pure_ldp/frequency_oracles/hadamard_response/hr_server.py
+++ b/pure_ldp/frequency_oracles/hadamard_response/hr_server.py
@@ -4,18 +4,22 @@ import math
 
 
 class HadamardResponseServer(FreqOracleServer):
-    def __init__(self, epsilon, d, index_mapper=None):
+    def __init__(self, epsilon, d, index_mapper=None, normalization=0):
         """
 
         Args:
-            epsilon:
-            d:
-            index_mapper:
+            epsilon (float): Privacy Budget
+            d (int): Domain size
+            index_mapper (Optional function): A function that maps domain elements to {0, ... d-1}
+            normalisation (Optional int): 0 (default) - No normalisation
+                           1 - Normalisation (+ clip to 0)
+                           2 - Projects estimates onto the probability simplex
         """
         super().__init__(epsilon, d, index_mapper=index_mapper)
         self.aggregated_data = []
         self.update_params(epsilon, d, index_mapper)
         self.set_name("Hadamard Response")
+        self.normalization = normalization
 
     def get_hash_funcs(self):
         if self.epsilon > 1:
@@ -60,7 +64,7 @@ class HadamardResponseServer(FreqOracleServer):
         Returns: estimated data
 
         """
-        self.estimated_data = self.hr.decode_string(self.aggregated_data) * self.n
+        self.estimated_data = self.hr.decode_string(self.aggregated_data, normalization=self.normalization-1) * self.n # k2khadamard using norm=0 for normalisation, 1 for simplex and anything else for none
         return self.estimated_data
 
     def estimate(self, data, suppress_warnings=False):

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
 from setuptools import setup, find_packages
 import shutil
+import os
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-shutil.rmtree("./build")
-shutil.rmtree("./dist")
-shutil.rmtree("./pure_ldp.egg-info")
+if os.path.exists("./build"):
+    shutil.rmtree("./build")
+if os.path.exists("./dist"):
+    shutil.rmtree("./dist")
+if os.path.exists("./pure_ldp.egg-info"):
+    shutil.rmtree("./pure_ldp.egg-info")
 
 setup(
     name='pure-ldp',


### PR DESCRIPTION
Bug fixes:
* Hadamard Response now works in low privacy mode (epsilon < 1)
* Hadamard response should properly work via PyPI

New:
* Hadamard Response server has an additional normalisation parameter -
    * If normalization = 0 then no normalisation is applied (default) 
    * If normalization = 1, the estimates are clipped to 0 and normalised
    * if normalization=2 then the estimates are projected onto the probability simplex